### PR TITLE
tidy up macOS release artefact

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with: 
         name: bin2h-darwin
-        path: build
+        path: build/bin2h
 
   build-windows:
 


### PR DESCRIPTION
trim the macOS artifact to only include the executable, and not any cmake build debris